### PR TITLE
fix: Docker ビルドで pnpm v11 動作に必要な Node.js を 22 LTS に更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
-FROM zenika/alpine-chrome:with-puppeteer-xvfb AS runner
+# pnpm v11 は Node.js v22.13+ を必要とするため、node:22-alpine をベースとして使用する。
+# zenika/alpine-chrome:with-puppeteer-xvfb (Alpine 3.19 / Node.js 20) は pnpm v11 に対応していない。
+FROM node:22-alpine AS runner
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PATH"
+
+# zenika/alpine-chrome:with-puppeteer-xvfb が設定していた Puppeteer 向け環境変数
+ENV CHROME_BIN=/usr/bin/chromium-browser \
+    CHROME_PATH=/usr/lib/chromium/ \
+    CHROMIUM_FLAGS="--disable-software-rasterizer --disable-dev-shm-usage" \
+    DISPLAY=:99 \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
 
 # hadolint ignore=DL3002
 USER root
@@ -9,7 +19,16 @@ USER root
 # hadolint ignore=DL3018,DL3016
 RUN apk upgrade --no-cache --available && \
   apk update && \
-  apk add --update --no-cache tzdata x11vnc && \
+  apk add --update --no-cache \
+    chromium \
+    chromium-swiftshader \
+    ttf-freefont \
+    font-noto-emoji \
+    font-wqy-zenhei \
+    tini \
+    tzdata \
+    x11vnc \
+    xvfb && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \


### PR DESCRIPTION
## 変更概要

pnpm v11 は Node.js v22.13+ を必要とするが、従来のベースイメージ `zenika/alpine-chrome:with-puppeteer-xvfb` は Alpine 3.19 / Node.js 20.15.1 を使用しており、pnpm v11 でのビルドが失敗していた。

## 問題の詳細

Renovate PR #2183 (`chore(deps): update pnpm to v11`) の Docker CI で以下のエラーが発生していた。

```
warn: This version of pnpm requires at least Node.js v22.13
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

`node:sqlite` は Node.js 22.5+ で追加されたビルトインモジュールであり、Node.js 20 では利用できない。

## 対応内容

`zenika/alpine-chrome:with-puppeteer-xvfb` を `node:22-alpine` に置き換え、以下のパッケージを手動で apk インストールするよう変更した。

- `chromium` / `chromium-swiftshader` - Chromium ブラウザ本体
- `xvfb` - 仮想ディスプレイ (元々 zenika イメージに含まれていた)
- `x11vnc` - VNC サーバ (元々手動追加していた)
- `tini` - PID 1 init プロセス (元々 zenika イメージに含まれていた)
- `ttf-freefont` / `font-noto-emoji` / `font-wqy-zenhei` - フォント類 (元々 zenika イメージに含まれていた)

また、zenika イメージが設定していた Puppeteer 向け環境変数 (`CHROME_BIN`, `CHROME_PATH`, `CHROMIUM_FLAGS`, `DISPLAY`, `PUPPETEER_EXECUTABLE_PATH`, `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`) を Dockerfile に明示的に追加した。

## 検証

ローカルにて以下の両パターンでのビルド成功を確認済み。

- pnpm v10.33.4 (現在の `master` の設定) でのビルド: 成功
- pnpm v11.1.3 (Renovate PR #2183 の設定) でのビルド: 成功

## 関連

- Renovate PR #2183: https://github.com/book000/kindle-booklog/pull/2183