### PR TITLE
feat: TypeScript v6 の非推奨設定を根本修正する

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,9 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "esnext.AsyncIterable", "DOM"],
+    "types": ["node"],
     "rootDir": "./src",
     "outDir": "./dist",
     "removeComments": true,
@@ -23,11 +24,9 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

TypeScript v6.0 で非推奨となった設定を根本的に修正し、TypeScript 7.0 への前方互換性を確保します。

Fixes #2283

## 変更内容

### `tsconfig.json`

| 設定 | 変更前 | 変更後 |
|------|--------|--------|
| `moduleResolution` | `Node` | `bundler` |
| `baseUrl` | `.` | 削除 |
| `paths["@/*"]` | `["src/*"]` | `["./src/*"]` |
| `ignoreDeprecations` | `"6.0"` | 削除 |
| `types` | （未設定）| `["node"]` |

## 変更の理由

- `moduleResolution: "Node"` は TypeScript 6.0 で非推奨となった。`bundler` が推奨代替
- `ignoreDeprecations: "6.0"` は TypeScript 7.0 以降では機能しなくなるため削除が必要
- `baseUrl: "."` を削除し、`paths` の参照を相対パス形式に修正
- TypeScript 6.0 より `@types/node` の自動読み込みが廃止されたため `types: ["node"]` を明示的に追加

## 動作確認

- [x] `pnpm lint:tsc` による型チェックが成功
- [x] `pnpm lint` による Lint チェック（Prettier・ESLint・TSC）が成功