### PR TITLE
fix: devcontainer の image タグを更新

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "kindle-booklog",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-18",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24",
   "remoteUser": "node",
   "otherPortsAttributes": {
     "onAutoForward": "silent"


### PR DESCRIPTION
## 変更内容

devcontainer の image タグを Renovate が自動更新できる形式に変更します。

### 変更

- `image`: `mcr.microsoft.com/devcontainers/typescript-node:1-18` → `mcr.microsoft.com/devcontainers/typescript-node:24`
- Node.js 18 (EOL) → 24 (LTS) へアップグレード

### 理由

`X-Y` 形式のタグ（例: `1-18`）や `X-OS` 形式（例: `24-bullseye`）は Renovate の devcontainer マネージャーが検出できないため、バージョン番号のみの形式（`24`）に統一します。

これにより将来の Node.js LTS 更新が Renovate で自動管理されます。

ref: book000/book000#118
