### PR TITLE
fix: eslint-config v1.15.44 の unicorn ルール適用に伴う lint エラーを解消

### DIFF
--- a/src/amazon.ts
+++ b/src/amazon.ts
@@ -25,7 +25,7 @@ export default class Amazon {
     public options: AmazonOptions,
     proxyOptions?: ProxyOptions
   ) {
-    this.options.isIgnoreCookie = this.options.isIgnoreCookie ?? false
+    this.options.isIgnoreCookie ??= false
     this.proxyOptions = proxyOptions
   }
 
@@ -43,19 +43,19 @@ export default class Amazon {
         await this.options.browser.setCookie(cookie)
       }
     }
-    await page
-      .goto(
+    try {
+      await page.goto(
         'https://read.amazon.co.jp/kindle-library?sortType=acquisition_asc',
         {
           waitUntil: 'networkidle2',
         }
       )
-      .catch(async () => {
-        await page.screenshot({
-          path: '/data/amazon-login0.png',
-          fullPage: true,
-        })
+    } catch {
+      await page.screenshot({
+        path: '/data/amazon-login0.png',
+        fullPage: true,
       })
+    }
 
     if (
       !this.options.isIgnoreCookie &&
@@ -63,97 +63,78 @@ export default class Amazon {
     ) {
       // already login?
       return
-    } else {
-      // need login
-      await page
-        .waitForSelector('button#top-sign-in-btn', {
-          visible: true,
-        })
-        .then(async (element) => {
-          await element?.click()
-        })
     }
+    // need login
+    const signInButton = await page.waitForSelector('button#top-sign-in-btn', {
+      visible: true,
+    })
+    await signInButton?.click()
 
     console.log("Waiting for 'div#authportal-center-section'")
-    await page
-      .waitForSelector('div#authportal-center-section', {
-        visible: true,
-      })
-      .then(async () => {
-        console.log(
-          "Found 'div#authportal-center-section'. Setting margin-top to 100px"
-        )
-        await page.evaluate(() => {
-          const centerSection = document.querySelector<HTMLDivElement>(
-            'div#authportal-center-section'
-          )
-          if (centerSection) {
-            centerSection.style.marginTop = '100px'
-          }
-        })
-      })
+    await page.waitForSelector('div#authportal-center-section', {
+      visible: true,
+    })
+    console.log(
+      "Found 'div#authportal-center-section'. Setting margin-top to 100px"
+    )
+    await page.evaluate(() => {
+      const centerSection = document.querySelector<HTMLDivElement>(
+        'div#authportal-center-section'
+      )
+      if (centerSection) {
+        centerSection.style.marginTop = '100px'
+      }
+    })
 
     console.log("Waiting for 'input#ap_email'")
-    await page
-      .waitForSelector('input#ap_email', {
-        visible: true,
-      })
-      .then(async (element) => {
-        console.log(
-          "Found 'input#ap_email'. Clicking 3 times and typing username"
-        )
-        await element?.click({ count: 3 })
-        await element?.type(this.options.username)
-      })
+    const emailInput = await page.waitForSelector('input#ap_email', {
+      visible: true,
+    })
+    console.log("Found 'input#ap_email'. Clicking 3 times and typing username")
+    await emailInput?.click({ count: 3 })
+    await emailInput?.type(this.options.username)
 
     await new Promise((resolve) => setTimeout(resolve, 3000))
 
     console.log("Waiting for 'input#continue'")
-    await page
-      .waitForSelector('input#continue', {
+    try {
+      const continueButton = await page.waitForSelector('input#continue', {
         visible: true,
         timeout: 3000,
       })
-      .then(async (element) => {
-        console.log("Found 'input#continue'. Clicking")
-        await element?.click()
-      })
-      .catch(() => null)
+      console.log("Found 'input#continue'. Clicking")
+      await continueButton?.click()
+    } catch {
+      // input#continue が表示されないケースがあるため無視する
+    }
 
     console.log("Waiting for 'div#authportal-center-section'")
-    await page
-      .waitForSelector('div#authportal-center-section', {
-        visible: true,
-      })
-      .then(async () => {
-        console.log(
-          "Found 'div#authportal-center-section'. Setting margin-top to 100px"
-        )
-        await page.evaluate(() => {
-          const centerSection = document.querySelector<HTMLDivElement>(
-            'div#authportal-center-section'
-          )
-          if (centerSection) {
-            centerSection.style.marginTop = '100px'
-          }
-        })
-      })
+    await page.waitForSelector('div#authportal-center-section', {
+      visible: true,
+    })
+    console.log(
+      "Found 'div#authportal-center-section'. Setting margin-top to 100px"
+    )
+    await page.evaluate(() => {
+      const centerSection = document.querySelector<HTMLDivElement>(
+        'div#authportal-center-section'
+      )
+      if (centerSection) {
+        centerSection.style.marginTop = '100px'
+      }
+    })
 
     await new Promise((resolve) => setTimeout(resolve, 3000))
 
     console.log("Waiting for 'input#ap_password'")
-    await page
-      .waitForSelector('input#ap_password', {
-        visible: true,
-      })
-      .then(async (element) => {
-        console.log(
-          "Found 'input#ap_password'. Clicking 3 times and typing password"
-        )
-
-        await element?.click({ count: 3 })
-        await element?.type(this.options.password)
-      })
+    const passwordInput = await page.waitForSelector('input#ap_password', {
+      visible: true,
+    })
+    console.log(
+      "Found 'input#ap_password'. Clicking 3 times and typing password"
+    )
+    await passwordInput?.click({ count: 3 })
+    await passwordInput?.type(this.options.password)
 
     await new Promise((resolve) => setTimeout(resolve, 3000))
 
@@ -177,11 +158,10 @@ export default class Amazon {
       const otpCode = await totp.generate({
         secret: this.options.otpSecret.replaceAll(' ', ''),
       })
-      await page
-        .waitForSelector('input#auth-mfa-otpcode', {
-          visible: true,
-        })
-        .then((element) => element?.type(otpCode))
+      const otpInput = await page.waitForSelector('input#auth-mfa-otpcode', {
+        visible: true,
+      })
+      await otpInput?.type(otpCode)
       await page.evaluate(() => {
         const rememberMe = document.querySelector<HTMLInputElement>(
           'input#auth-mfa-remember-device'
@@ -192,11 +172,15 @@ export default class Amazon {
       })
 
       await Promise.all([
-        page
-          .waitForSelector('input#auth-signin-button', {
-            visible: true,
-          })
-          .then((element) => element?.click()),
+        (async () => {
+          const authSignInButton = await page.waitForSelector(
+            'input#auth-signin-button',
+            {
+              visible: true,
+            }
+          )
+          await authSignInButton?.click()
+        })(),
         page.waitForNavigation(),
       ])
     }

--- a/src/booklog-update-book.ts
+++ b/src/booklog-update-book.ts
@@ -77,11 +77,15 @@ export default class BooklogUpdateBook {
   private async save() {
     // 保存ボタンを押して画面が遷移するのを待つ
     await Promise.all([
-      this.page
-        .waitForSelector('div#edit_panels p.buttons button[type="submit"]', {
-          visible: true,
-        })
-        .then((element) => element?.click()),
+      (async () => {
+        const submitButton = await this.page.waitForSelector(
+          'div#edit_panels p.buttons button[type="submit"]',
+          {
+            visible: true,
+          }
+        )
+        await submitButton?.click()
+      })(),
       this.page.waitForNavigation({
         waitUntil: 'networkidle2',
       }),
@@ -104,16 +108,20 @@ export default class BooklogUpdateBook {
     const statusId = `status${statusValue}_1_${this.itemId}`
 
     // 読書状況を変更する
-    await this.page
-      .waitForSelector(`td#status p.edit-status > label[for="${statusId}"]`, {
+    const statusLabelToScroll = await this.page.waitForSelector(
+      `td#status p.edit-status > label[for="${statusId}"]`,
+      {
         visible: true,
-      })
-      .then((element) => element?.scrollIntoView())
-    await this.page
-      .waitForSelector(`td#status p.edit-status > label[for="${statusId}"]`, {
+      }
+    )
+    await statusLabelToScroll?.scrollIntoView()
+    const statusLabelToClick = await this.page.waitForSelector(
+      `td#status p.edit-status > label[for="${statusId}"]`,
+      {
         visible: true,
-      })
-      .then((element) => element?.click())
+      }
+    )
+    await statusLabelToClick?.click()
   }
 
   /**
@@ -129,18 +137,24 @@ export default class BooklogUpdateBook {
 
     // 未設定の場合は「読了日を指定しない」にチェックを入れる
     if (readAt === null || readAt === '') {
-      const isReadAtNullChecked = await this.page
-        .waitForSelector('td#status div#read_at input#read_at_null', {
+      const readAtNullCheckbox = await this.page.waitForSelector(
+        'td#status div#read_at input#read_at_null',
+        {
           visible: true,
-        })
-        .then((element) => element?.evaluate((el) => el.checked))
+        }
+      )
+      const isReadAtNullChecked = await readAtNullCheckbox?.evaluate(
+        (element_) => element_.checked
+      )
 
       if (!isReadAtNullChecked) {
-        await this.page
-          .waitForSelector('td#status div#read_at label[for="read_at_null"]', {
+        const readAtNullLabel = await this.page.waitForSelector(
+          'td#status div#read_at label[for="read_at_null"]',
+          {
             visible: true,
-          })
-          .then((element) => element?.click())
+          }
+        )
+        await readAtNullLabel?.click()
       }
       return
     }
@@ -153,13 +167,16 @@ export default class BooklogUpdateBook {
     }
 
     // 読了日を入力する
-    await this.page
-      .waitForSelector('td#status div#read_at input#read-date', {
+    const readDateInput = await this.page.waitForSelector(
+      'td#status div#read_at input#read-date',
+      {
         visible: true,
-      })
-      .then((element) =>
-        element?.evaluate((el, readAt) => (el.value = readAt), readAt)
-      )
+      }
+    )
+    await readDateInput?.evaluate(
+      (element_, readAt) => (element_.value = readAt),
+      readAt
+    )
   }
 
   /**
@@ -178,11 +195,13 @@ export default class BooklogUpdateBook {
 
     // 評価を設定する
     const rateValue = rate ?? 'x'
-    await this.page
-      .waitForSelector(`div.edit-rating img[alt="${rateValue}"]`, {
+    const rateImage = await this.page.waitForSelector(
+      `div.edit-rating img[alt="${rateValue}"]`,
+      {
         visible: true,
-      })
-      .then((element) => element?.click())
+      }
+    )
+    await rateImage?.click()
   }
 
   /**
@@ -204,13 +223,16 @@ export default class BooklogUpdateBook {
     })
 
     // 読了日を入力する
-    await this.page
-      .waitForSelector('div.edit-review-area textarea#edit-review', {
+    const reviewTextarea = await this.page.waitForSelector(
+      'div.edit-review-area textarea#edit-review',
+      {
         visible: true,
-      })
-      .then((element) =>
-        element?.evaluate((el, review) => (el.value = review), review)
-      )
+      }
+    )
+    await reviewTextarea?.evaluate(
+      (element_, review) => (element_.value = review),
+      review
+    )
 
     // 「ネタバレの内容を含む」のチェックボックスを更新する
     if (isSpoiler !== undefined) {
@@ -220,7 +242,9 @@ export default class BooklogUpdateBook {
           visible: true,
         }
       )
-      const isChecked = await netabareInputElement?.evaluate((el) => el.checked)
+      const isChecked = await netabareInputElement?.evaluate(
+        (element) => element.checked
+      )
       if (isChecked !== isSpoiler) {
         await netabareInputElement?.click()
       }
@@ -239,13 +263,13 @@ export default class BooklogUpdateBook {
     })
 
     // タグを設定する
-    await this.page
-      .waitForSelector('textarea#tags', {
-        visible: true,
-      })
-      .then((element) =>
-        element?.evaluate((el, tags) => (el.value = tags), tags.join(' '))
-      )
+    const tagsTextarea = await this.page.waitForSelector('textarea#tags', {
+      visible: true,
+    })
+    await tagsTextarea?.evaluate(
+      (element_, tags) => (element_.value = tags),
+      tags.join(' ')
+    )
   }
 
   /**
@@ -268,13 +292,13 @@ export default class BooklogUpdateBook {
     })
 
     // 読書メモを入力する
-    await this.page
-      .waitForSelector('textarea#memo', {
-        visible: true,
-      })
-      .then((element) =>
-        element?.evaluate((el, memo) => (el.value = memo), memo)
-      )
+    const memoTextarea = await this.page.waitForSelector('textarea#memo', {
+      visible: true,
+    })
+    await memoTextarea?.evaluate(
+      (element_, memo) => (element_.value = memo),
+      memo
+    )
   }
 
   /**
@@ -287,17 +311,17 @@ export default class BooklogUpdateBook {
     })
 
     // 非公開登録のオプションを更新する
-    const isPrivateCheckboxElement = await this.page.waitForSelector(
+    const privateCheckbox = await this.page.waitForSelector(
       'input#book_secret',
       {
         visible: true,
       }
     )
-    const isChecked = await isPrivateCheckboxElement?.evaluate(
-      (el) => el.checked
+    const isChecked = await privateCheckbox?.evaluate(
+      (element) => element.checked
     )
     if (isChecked !== isPrivate) {
-      await isPrivateCheckboxElement?.click()
+      await privateCheckbox?.click()
     }
   }
 

--- a/src/booklog.ts
+++ b/src/booklog.ts
@@ -112,27 +112,29 @@ export default class Booklog {
       return
     }
 
-    await page
-      .waitForSelector('input#account', {
-        visible: true,
-      })
-      .then((element) => element?.type(this.options.username))
+    const accountInput = await page.waitForSelector('input#account', {
+      visible: true,
+    })
+    await accountInput?.type(this.options.username)
 
-    await page
-      .waitForSelector('input#password', {
-        visible: true,
-      })
-      .then((element) => element?.type(this.options.password))
+    const passwordInput = await page.waitForSelector('input#password', {
+      visible: true,
+    })
+    await passwordInput?.type(this.options.password)
 
     fs.writeFileSync('/data/booklog-login.html', await page.content())
 
     // ログインボタンを押して画面が遷移するのを待つ
     await Promise.all([
-      page
-        .waitForSelector('button#login_submit_button', {
-          visible: true,
-        })
-        .then((element) => element?.click()),
+      (async () => {
+        const loginSubmitButton = await page.waitForSelector(
+          'button#login_submit_button',
+          {
+            visible: true,
+          }
+        )
+        await loginSubmitButton?.click()
+      })(),
       page.waitForNavigation({
         waitUntil: 'networkidle2',
       }),
@@ -220,13 +222,20 @@ export default class Booklog {
       waitUntil: 'networkidle2',
     })
     await Promise.all([
-      page
-        .waitForSelector('button#item-add-button', {
-          visible: true,
-          timeout: 3000,
-        })
-        .then((element) => element?.click())
-        .catch(() => null),
+      (async () => {
+        try {
+          const itemAddButton = await page.waitForSelector(
+            'button#item-add-button',
+            {
+              visible: true,
+              timeout: 3000,
+            }
+          )
+          await itemAddButton?.click()
+        } catch {
+          // button#item-add-button が表示されないケース (登録済み等) は無視する
+        }
+      })(),
       page.waitForNavigation(),
     ])
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,11 +41,10 @@ async function addNewBooks(
   const logger = Logger.configure('addNewBooks')
   logger.info('Start adding new books')
 
-  const newBooks = kindleBooks.filter(
-    (kindleBook) =>
-      !booklogBooks.some(
-        (book) => book.itemId.toUpperCase() === kindleBook.asin.toUpperCase()
-      )
+  const newBooks = kindleBooks.filter((kindleBook) =>
+    booklogBooks.every(
+      (book) => book.itemId.toUpperCase() !== kindleBook.asin.toUpperCase()
+    )
   )
 
   for (const book of newBooks) {
@@ -139,9 +138,12 @@ async function updateUnsetStatusBooks(
       logger.info('This book is not unsupported kindle for web')
       continue
     }
-    const percentageRead = await amazon
-      .getBookPercentageRead(kindleBook)
-      .catch(() => null)
+    let percentageRead: number | null
+    try {
+      percentageRead = await amazon.getBookPercentageRead(kindleBook)
+    } catch {
+      percentageRead = null
+    }
     logger.info(`Percentage read: ${percentageRead}`)
     if (percentageRead === null) {
       continue
@@ -213,9 +215,12 @@ async function updateAllBooks(
       logger.info('This book is not unsupported kindle for web')
       continue
     }
-    const percentageRead = await amazon
-      .getBookPercentageRead(kindleBook)
-      .catch(() => null)
+    let percentageRead: number | null
+    try {
+      percentageRead = await amazon.getBookPercentageRead(kindleBook)
+    } catch {
+      percentageRead = null
+    }
     logger.info(`Percentage read: ${percentageRead}`)
     if (percentageRead === null) {
       continue
@@ -342,8 +347,8 @@ async function main() {
       // 全ての本情報を更新
       await updateAllBooks(amazon, booklog, discord, kindleBooks, booklogBooks)
     }
-  } catch (err) {
-    logger.error('Error occurred', err as Error)
+  } catch (error) {
+    logger.error('Error occurred', error as Error)
     const debugDirectory = process.env.DEBUG_DIRECTORY ?? 'debug'
     const pages = await browser.pages()
     if (!fs.existsSync(debugDirectory)) {
@@ -372,9 +377,9 @@ async function main() {
         {
           title: 'エラーが発生しました',
           description:
-            err instanceof Error
-              ? err.message + '\n\n' + (err.stack ?? '')
-              : String(err),
+            error instanceof Error
+              ? error.message + '\n\n' + (error.stack ?? '')
+              : String(error),
           color: 0xff_00_00, // red
           footer: {
             text: 'Powered by kindle-booklog',
@@ -388,7 +393,9 @@ async function main() {
 }
 
 ;(async () => {
-  await main().catch((err: unknown) => {
-    console.error(err)
-  })
+  try {
+    await main()
+  } catch (error: unknown) {
+    console.error(error)
+  }
 })()

--- a/src/proxy-auth.ts
+++ b/src/proxy-auth.ts
@@ -7,12 +7,14 @@ export interface ProxyOptions {
 }
 
 export async function authProxy(page: Page, config: ProxyOptions) {
-  if (config.username && config.password) {
-    console.log('Login proxy')
-    await page.authenticate({
-      username: config.username,
-      password: config.password,
-    })
-    console.log('Login proxy... done')
+  if (!(config.username && config.password)) {
+    return
   }
+
+  console.log('Login proxy')
+  await page.authenticate({
+    username: config.username,
+    password: config.password,
+  })
+  console.log('Login proxy... done')
 }


### PR DESCRIPTION
## 概要

Renovate PR #2307 (`@book000/eslint-config` 1.15.4 -> 1.15.44) が `eslint-plugin-unicorn` の新しいルールセットを引き込み、既存コードの `src/amazon.ts` / `src/booklog-update-book.ts` / `src/booklog.ts` / `src/main.ts` / `src/proxy-auth.ts` で計 42 件の lint エラーが発生していました。本 PR はそれらを機械的に解消します。

## 対応内容

- `unicorn/prefer-await`: `.then()`/`.catch()` によるチェーンを `await`/`try-catch` に置き換え（`Promise.all` 内は挙動維持のため即時実行の async 関数でラップ）
- `unicorn/name-replacements`: `el` -> `element`/`element_`、`err` -> `error`（--fix で自動修正）
- `unicorn/consistent-boolean-name`: `isPrivateCheckboxElement` -> `privateCheckbox`（真偽値ではなく ElementHandle のため）
- `unicorn/logical-assignment-operators`: `??=` へ置き換え（--fix で自動修正）
- `unicorn/no-useless-else` / `unicorn/no-negated-array-predicate`: --fix で自動修正

挙動は変更していません。本 PR 自体は `@book000/eslint-config` のバージョンを上げていません（Renovate PR #2307 とは別に、`master` からブランチしています）。

## 動作確認

- `pnpm run lint`（prettier + eslint + tsc）: 現行の `@book000/eslint-config@1.15.4` / バンプ後の `1.15.44` の両方でクリーンであることを確認済み

Renovate PR: #2307