### PR TITLE
fix(deps): prettier 3.9.4 対応のため src/booklog.ts を再フォーマット

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-promise": "7.3.0",
     "iconv-lite": "0.7.3",
     "otplib": "13.4.1",
-    "prettier": "3.8.5",
+    "prettier": "3.9.4",
     "puppeteer-core": "25.3.0",
     "run-z": "2.1.0",
     "tar-stream": "3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 13.4.1
         version: 13.4.1
       prettier:
-        specifier: 3.8.5
-        version: 3.8.5
+        specifier: 3.9.4
+        version: 3.9.4
       puppeteer-core:
         specifier: 25.3.0
         version: 25.3.0(yauzl@2.10.0)
@@ -1478,8 +1478,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.5:
-    resolution: {integrity: sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==}
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3415,7 +3415,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.5: {}
+  prettier@3.9.4: {}
 
   prop-types@15.8.1:
     dependencies:

--- a/src/booklog.ts
+++ b/src/booklog.ts
@@ -15,11 +15,7 @@ interface BooklogOptions {
 
 // サービスID, アイテムID, 13桁ISBN, カテゴリ, 評価, 読書状況, レビュー, タグ, 読書メモ(非公開), 登録日時, 読了日, タイトル, 作者名, 出版社名, 発行年, ジャンル, ページ数
 export type BookStatus =
-  | '読みたい'
-  | 'いま読んでる'
-  | '読み終わった'
-  | '積読'
-  | '' // 未設定は空文字列
+  '読みたい' | 'いま読んでる' | '読み終わった' | '積読' | '' // 未設定は空文字列
 export interface BooklogBook {
   /** サービスID */
   serviceId: number


### PR DESCRIPTION
## 概要

Renovate PR #2331 (`prettier` 3.8.5 -> 3.9.4) の CI 失敗 (`Node CI / node-ci (.)`, `Node CI / Check finished Node CI`) を修正します。

## 原因

prettier 3.9 系で行幅の計算が変わり、`src/booklog.ts` の `BookStatus` ユニオン型 (末尾に日本語インラインコメント付き) の整形結果が変化しました。これにより `lint:prettier`(`prettier --check src`) が失敗していました (`lint:tsc`/`lint:eslint` は問題なし)。

## 対応

- `package.json` / `pnpm-lock.yaml` の `prettier` を 3.9.4 に更新 (#2331 と同内容)
- `prettier --write src` で `src/booklog.ts` のみ再フォーマット (機械的な整形のみ、ロジック変更なし)

## 確認

- `pnpm exec prettier --check src` → pass
- `pnpm exec tsc --noEmit` → pass
- `pnpm exec eslint . -c eslint.config.mjs` → pass
