### PR TITLE
fix: Amazonログインの画面遷移を同期する

### DIFF
--- a/src/amazon.test.ts
+++ b/src/amazon.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import type { Browser } from 'puppeteer-core'
+import Amazon from './amazon'
+
+class FakeAmazonLoginPage {
+  public waitForNavigationOptions: { waitUntil?: string }[] = []
+  private navigationWaitRegistered = false
+  private currentUrl = 'about:blank'
+
+  public goto(): Promise<void> {
+    this.currentUrl = 'https://read.amazon.co.jp/landing'
+    return Promise.resolve()
+  }
+
+  public url(): string {
+    return this.currentUrl
+  }
+
+  public title(): Promise<string> {
+    return Promise.resolve('Amazon Sign-In')
+  }
+
+  public waitForNavigation(options?: { waitUntil?: string }): Promise<void> {
+    this.waitForNavigationOptions.push(options ?? {})
+    this.navigationWaitRegistered = true
+    return Promise.resolve()
+  }
+
+  public waitForSelector(
+    selector: string
+  ): Promise<{ click?: () => Promise<void> }> {
+    if (selector === 'button#top-sign-in-btn') {
+      return Promise.resolve({
+        click: () => {
+          this.currentUrl = 'https://www.amazon.co.jp/ap/signin'
+          return Promise.resolve()
+        },
+      })
+    }
+
+    if (selector === 'div#authportal-center-section') {
+      if (!this.navigationWaitRegistered) {
+        return Promise.reject(
+          new Error('Amazon sign-in navigation was not awaited')
+        )
+      }
+      return Promise.resolve({})
+    }
+
+    if (selector === 'input#ap_email') {
+      return Promise.reject(new Error('reached Amazon email input'))
+    }
+
+    return Promise.reject(new Error(`unexpected selector: ${selector}`))
+  }
+
+  public evaluate(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+function createAmazon(page: FakeAmazonLoginPage): Amazon {
+  const browser = {
+    newPage: () => Promise.resolve(page),
+  } as unknown as Browser
+
+  return new Amazon({
+    browser,
+    username: 'test@example.com',
+    password: 'password',
+    isIgnoreCookie: true,
+  })
+}
+
+test('Amazon のサインイン遷移完了後に認証フォームを待つ', async () => {
+  const page = new FakeAmazonLoginPage()
+  const amazon = createAmazon(page)
+
+  await assert.rejects(amazon.login(), /reached Amazon email input/)
+
+  assert.deepEqual(page.waitForNavigationOptions, [
+    { waitUntil: 'domcontentloaded' },
+  ])
+}).catch((error: unknown) => {
+  throw error
+})

--- a/src/amazon.ts
+++ b/src/amazon.ts
@@ -132,7 +132,10 @@ export default class Amazon {
       'wait top sign-in button',
       { visible: true }
     ).then(async (element) => {
-      await element?.click()
+      await Promise.all([
+        page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+        element?.click(),
+      ])
     })
 
     console.log("Waiting for 'div#authportal-center-section'")


### PR DESCRIPTION
## 概要

Amazonログイン時、Kindleのサインインボタン押下直後に `waitForSelector` を開始すると、永続 `userDataDir` 再利用時にページ遷移を跨いだ WaitTask が完了せず、認証フォームが実際には表示されていても30秒でタイムアウトする問題を修正します。

## 変更内容

- サインインボタン押下と `page.waitForNavigation({ waitUntil: 'domcontentloaded' })` を `Promise.all` で同期
- navigation完了後にAmazon認証フォームのselector待機へ進むよう変更
- navigation待機が行われることを確認する回帰テストを追加

## 確認

- 修正前: 追加した回帰テストが `Amazon sign-in navigation was not awaited` で失敗することを確認
- `pnpm test`: 10 tests passed
- `pnpm lint`: passed
- `pnpm compile`: passed
- `git diff --check`: passed
- Chromium + rebrowser-puppeteer-core 24.8.1 で同じ永続プロファイルを2回連続利用し、2回とも `div#authportal-center-section` の待機成功を確認