### PR TITLE
fix: Amazonログインの全画面遷移を同期する

### DIFF
--- a/src/amazon.test.ts
+++ b/src/amazon.test.ts
@@ -3,13 +3,25 @@ import { test } from 'node:test'
 import type { Browser } from 'puppeteer-core'
 import Amazon from './amazon'
 
+type LoginStage = 'landing' | 'email' | 'password' | 'mfa' | 'library'
+
+interface FakeAmazonLoginPageOptions {
+  hasContinue?: boolean
+  requireMfa?: boolean
+}
+
 class FakeAmazonLoginPage {
   public waitForNavigationOptions: { waitUntil?: string }[] = []
-  private navigationWaitRegistered = false
+  public unsynchronizedActions: string[] = []
   private currentUrl = 'about:blank'
+  private stage: LoginStage = 'landing'
+  private navigationResolver?: () => void
+
+  constructor(private options: FakeAmazonLoginPageOptions = {}) {}
 
   public goto(): Promise<void> {
     this.currentUrl = 'https://read.amazon.co.jp/landing'
+    this.stage = 'landing'
     return Promise.resolve()
   }
 
@@ -23,64 +35,198 @@ class FakeAmazonLoginPage {
 
   public waitForNavigation(options?: { waitUntil?: string }): Promise<void> {
     this.waitForNavigationOptions.push(options ?? {})
-    this.navigationWaitRegistered = true
-    return Promise.resolve()
+    return new Promise((resolve) => {
+      this.navigationResolver = resolve
+    })
   }
 
-  public waitForSelector(
-    selector: string
-  ): Promise<{ click?: () => Promise<void> }> {
+  private navigate(label: string, url: string, stage: LoginStage): void {
+    if (this.navigationResolver) {
+      const resolve = this.navigationResolver
+      this.navigationResolver = undefined
+      this.currentUrl = url
+      this.stage = stage
+      resolve()
+      return
+    }
+
+    this.unsynchronizedActions.push(label)
+    this.currentUrl = url
+    this.stage = stage
+  }
+
+  public waitForSelector(selector: string): Promise<Record<string, unknown>> {
     if (selector === 'button#top-sign-in-btn') {
       return Promise.resolve({
         click: () => {
-          this.currentUrl = 'https://www.amazon.co.jp/ap/signin'
+          this.navigate(
+            'top sign-in',
+            'https://www.amazon.co.jp/ap/signin',
+            'email'
+          )
           return Promise.resolve()
         },
       })
     }
 
     if (selector === 'div#authportal-center-section') {
-      if (!this.navigationWaitRegistered) {
-        return Promise.reject(
-          new Error('Amazon sign-in navigation was not awaited')
-        )
-      }
       return Promise.resolve({})
     }
 
     if (selector === 'input#ap_email') {
-      return Promise.reject(new Error('reached Amazon email input'))
+      return Promise.resolve({
+        click: () => Promise.resolve(),
+        type: () => {
+          if (this.options.hasContinue === false) this.stage = 'password'
+          return Promise.resolve()
+        },
+      })
+    }
+
+    if (selector === 'input#continue') {
+      if (this.options.hasContinue === false) {
+        return Promise.reject(new Error('continue button not shown'))
+      }
+      return Promise.resolve({
+        click: () => {
+          this.navigate(
+            'continue',
+            'https://www.amazon.co.jp/ap/signin',
+            'password'
+          )
+          return Promise.resolve()
+        },
+      })
+    }
+
+    if (selector === 'input#ap_password') {
+      if (this.stage !== 'password') {
+        return Promise.reject(new Error(`password requested at ${this.stage}`))
+      }
+      return Promise.resolve({
+        click: () => Promise.resolve(),
+        type: () => Promise.resolve(),
+      })
+    }
+
+    if (selector === 'input#auth-mfa-otpcode') {
+      return Promise.resolve({ type: () => Promise.resolve() })
+    }
+
+    if (selector === 'input#auth-signin-button') {
+      return Promise.resolve({
+        click: () => {
+          this.navigate(
+            'MFA submit',
+            'https://read.amazon.co.jp/kindle-library',
+            'library'
+          )
+          return Promise.resolve()
+        },
+      })
     }
 
     return Promise.reject(new Error(`unexpected selector: ${selector}`))
   }
 
+  public click(selector: string): Promise<void> {
+    if (selector !== 'input#signInSubmit') {
+      return Promise.reject(new Error(`unexpected click: ${selector}`))
+    }
+    const requireMfa = this.options.requireMfa === true
+    this.navigate(
+      'password submit',
+      requireMfa
+        ? 'https://www.amazon.co.jp/ap/mfa'
+        : 'https://read.amazon.co.jp/kindle-library',
+      requireMfa ? 'mfa' : 'library'
+    )
+    return Promise.resolve()
+  }
+
   public evaluate(): Promise<void> {
     return Promise.resolve()
   }
+
+  public close(): Promise<void> {
+    return Promise.resolve()
+  }
 }
-function createAmazon(page: FakeAmazonLoginPage): Amazon {
+
+function createAmazon(
+  page: FakeAmazonLoginPage,
+  options: { otpSecret?: string } = {}
+): Amazon {
   const browser = {
     newPage: () => Promise.resolve(page),
+    cookies: () => Promise.resolve([]),
   } as unknown as Browser
 
   return new Amazon({
     browser,
     username: 'test@example.com',
     password: 'password',
+    otpSecret: options.otpSecret,
+    cookiePath: '/tmp/kindle-booklog-amazon-test-cookie.json',
     isIgnoreCookie: true,
   })
 }
 
-test('Amazon のサインイン遷移完了後に認証フォームを待つ', async () => {
+async function withoutLoginDelays(action: () => Promise<void>): Promise<void> {
+  const originalSetTimeout = setTimeout
+  globalThis.setTimeout = ((callback: () => void) => {
+    queueMicrotask(callback)
+    return 0 as unknown as NodeJS.Timeout
+  }) as typeof setTimeout
+
+  try {
+    await action()
+  } finally {
+    globalThis.setTimeout = originalSetTimeout
+  }
+}
+
+async function assertSynchronizedLogin(
+  page: FakeAmazonLoginPage,
+  amazon: Amazon,
+  expectedNavigationCount: number
+): Promise<void> {
+  await withoutLoginDelays(() => amazon.login())
+  assert.deepEqual(page.unsynchronizedActions, [])
+  assert.equal(page.waitForNavigationOptions.length, expectedNavigationCount)
+  assert.deepEqual(
+    page.waitForNavigationOptions,
+    Array.from({ length: expectedNavigationCount }, () => ({
+      waitUntil: 'domcontentloaded',
+    }))
+  )
+}
+
+test('Amazon の全ログイン遷移で navigation 待機を先に登録する', async () => {
   const page = new FakeAmazonLoginPage()
   const amazon = createAmazon(page)
 
-  await assert.rejects(amazon.login(), /reached Amazon email input/)
+  await assertSynchronizedLogin(page, amazon, 3)
+}).catch((error: unknown) => {
+  throw error
+})
 
-  assert.deepEqual(page.waitForNavigationOptions, [
-    { waitUntil: 'domcontentloaded' },
-  ])
+test('Amazon の Continue がない場合もパスワード送信を同期する', async () => {
+  const page = new FakeAmazonLoginPage({ hasContinue: false })
+  const amazon = createAmazon(page)
+
+  await assertSynchronizedLogin(page, amazon, 2)
+}).catch((error: unknown) => {
+  throw error
+})
+
+test('Amazon の MFA 送信まで全 navigation を同期する', async () => {
+  const page = new FakeAmazonLoginPage({ requireMfa: true })
+  const amazon = createAmazon(page, {
+    otpSecret: 'JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP',
+  })
+
+  await assertSynchronizedLogin(page, amazon, 4)
 }).catch((error: unknown) => {
   throw error
 })

--- a/src/amazon.ts
+++ b/src/amazon.ts
@@ -92,6 +92,16 @@ export default class Amazon {
     }
   }
 
+  private async performNavigationAction(
+    page: Page,
+    action: () => Promise<unknown>
+  ): Promise<void> {
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
+      action(),
+    ])
+  }
+
   public async login(): Promise<void> {
     console.log('Amazon.login()')
     const page = await this.options.browser.newPage()
@@ -132,10 +142,8 @@ export default class Amazon {
       'wait top sign-in button',
       { visible: true }
     ).then(async (element) => {
-      await Promise.all([
-        page.waitForNavigation({ waitUntil: 'domcontentloaded' }),
-        element?.click(),
-      ])
+      if (!element) return
+      await this.performNavigationAction(page, () => element.click())
     })
 
     console.log("Waiting for 'div#authportal-center-section'")
@@ -173,16 +181,16 @@ export default class Amazon {
     await new Promise((resolve) => setTimeout(resolve, 3000))
 
     console.log("Waiting for 'input#continue'")
-    await page
+    const continueButton = await page
       .waitForSelector(LOGIN_SELECTORS.continueButton, {
         visible: true,
         timeout: 3000,
       })
-      .then(async (element) => {
-        console.log("Found 'input#continue'. Clicking")
-        await element?.click()
-      })
       .catch(() => null)
+    if (continueButton) {
+      console.log("Found 'input#continue'. Clicking")
+      await this.performNavigationAction(page, () => continueButton.click())
+    }
 
     console.log("Waiting for 'div#authportal-center-section'")
     await this.waitForSelectorWithDiagnostics(
@@ -230,7 +238,9 @@ export default class Amazon {
         rememberMe.checked = true
       }
     })
-    await page.click(LOGIN_SELECTORS.signInSubmit)
+    await this.performNavigationAction(page, () =>
+      page.click(LOGIN_SELECTORS.signInSubmit)
+    )
     await new Promise((resolve) => setTimeout(resolve, 3000))
 
     if (
@@ -260,15 +270,15 @@ export default class Amazon {
         }
       })
 
-      await Promise.all([
-        this.waitForSelectorWithDiagnostics(
-          page,
-          LOGIN_SELECTORS.mfaSignInButton,
-          'wait MFA sign-in button',
-          { visible: true }
-        ).then((element) => element?.click()),
-        page.waitForNavigation(),
-      ])
+      const mfaSignInButton = await this.waitForSelectorWithDiagnostics(
+        page,
+        LOGIN_SELECTORS.mfaSignInButton,
+        'wait MFA sign-in button',
+        { visible: true }
+      )
+      if (mfaSignInButton) {
+        await this.performNavigationAction(page, () => mfaSignInButton.click())
+      }
     }
 
     const cookies = await this.options.browser.cookies()


### PR DESCRIPTION
## 概要

v3.22.15 で top sign-in の遷移同期は修正しましたが、本番でメール入力後の Continue → password page に同じ WaitTask レースが残っていることを確認しました。

Amazonログイン中に navigation を起こす全クリックを、`waitForNavigation({ waitUntil: 'domcontentloaded' })` を先に登録してから実行する共通処理へ統一します。

## 変更内容

- navigation + action を同期する `performNavigationAction` を追加
- top sign-in / Continue / password submit / MFA submit を同じ同期方式へ統一
- Continue が表示されない既存フローはそのまま許容
- Continue の selector 不在だけを無視し、navigation failure は握りつぶさない構造へ変更
- 通常ログイン / Continueなし / MFAありの回帰テストを追加

## TDD確認

修正前に追加テストを実行し、以下の未同期操作を検出して失敗することを確認しました。

- `continue`
- `password submit`

修正後は全ケースで未同期操作 0 件です。

## 検証

- `pnpm test`: 12/12 passed
- `pnpm lint`: passed
- `pnpm compile`: passed
- `git diff --check`: passed
- Chromium + rebrowser-puppeteer-core 24.8.1 で永続 `userDataDir` を再利用し、メール → パスワード → MFA → Kindle library の複数navigationを2回連続実行
  - run 1: PASS（MFA + final library reached）
  - run 2: PASS（MFA + final library reached）

Spec/Planおよび統合検証用一時スクリプトはコミットしていません。