### PR TITLE
fix: Chromium起動時のWS endpoint timeoutを診断・再試行可能にする

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -249,9 +249,6 @@ async function updateAllBooks(
   })
 }
 
-/**
- * Chromium のプロファイルロックファイル名一覧
- */
 const CHROMIUM_SINGLETON_LOCK_FILES = [
   'SingletonLock',
   'SingletonCookie',
@@ -259,7 +256,7 @@ const CHROMIUM_SINGLETON_LOCK_FILES = [
 ]
 
 /**
- * Chromium 起動失敗時の診断情報(DISPLAY/Xvfb ソケット・userDataDir のロックファイル状態)をログに出力する
+ * Chromium 起動失敗時の診断情報をログに出力する
  *
  * @param logger ロガー
  * @param userDataDir Chromium の userDataDir パス
@@ -290,7 +287,7 @@ function logChromiumLaunchDiagnostics(logger: Logger, userDataDir: string) {
 }
 
 /**
- * userDataDir 配下の Chromium のロックファイル(Singleton*)を削除する
+ * リトライ前に stale なロックが残ったままにならないよう、Singleton* を削除する
  *
  * @param userDataDir Chromium の userDataDir パス
  */
@@ -315,6 +312,7 @@ async function launchBrowserWithDiagnostics(
   logger: Logger
 ): Promise<Browser> {
   const userDataDir = options.userDataDir ?? ''
+  let firstAttemptError: unknown
 
   logger.info('Launching Chromium (attempt 1/2)')
   logChromiumLaunchDiagnostics(logger, userDataDir)
@@ -322,6 +320,7 @@ async function launchBrowserWithDiagnostics(
   try {
     return await puppeteer.launch(options)
   } catch (error) {
+    firstAttemptError = error
     logger.error('Failed to launch Chromium (attempt 1/2)', error as Error)
     // ロック削除前の状態を記録してから自衛的なクリーンアップを行う
     logChromiumLaunchDiagnostics(logger, userDataDir)
@@ -337,7 +336,9 @@ async function launchBrowserWithDiagnostics(
   } catch (error) {
     logger.error('Failed to launch Chromium (attempt 2/2)', error as Error)
     logChromiumLaunchDiagnostics(logger, userDataDir)
-    throw error
+    throw new Error('Failed to launch Chromium after retry', {
+      cause: { firstAttemptError, secondAttemptError: error },
+    })
   }
 }
 
@@ -365,7 +366,7 @@ async function main() {
     headless: !process.env.DISPLAY,
     executablePath: process.env.CHROMIUM_PATH ?? '/usr/bin/chromium-browser',
     userDataDir,
-    // 起動失敗時の診断のため、Chromium自身のstdout/stderrをそのまま出力する
+    // 起動失敗時の診断のため、Chromium 自身の stdout/stderr をそのまま出力する
     dumpio: true,
     defaultViewport: {
       width,
@@ -396,21 +397,28 @@ async function main() {
     browser = await launchBrowserWithDiagnostics(puppeteerOptions, logger)
   } catch (error) {
     logger.error('Failed to launch Chromium', error as Error)
-    await discord.sendMessage({
-      embeds: [
-        {
-          title: 'Chromiumの起動に失敗しました',
-          description:
-            error instanceof Error
-              ? error.message + '\n\n' + (error.stack ?? '')
-              : String(error),
-          color: 0xff_00_00, // red
-          footer: {
-            text: 'Powered by kindle-booklog',
+    // Discord API の embed description は 4096 文字までのため切り詰める
+    const description = (
+      error instanceof Error
+        ? error.message + '\n\n' + (error.stack ?? '')
+        : String(error)
+    ).slice(0, 4096)
+    try {
+      await discord.sendMessage({
+        embeds: [
+          {
+            title: 'Chromiumの起動に失敗しました',
+            description,
+            color: 0xff_00_00, // red
+            footer: {
+              text: 'Powered by kindle-booklog',
+            },
           },
-        },
-      ],
-    })
+        ],
+      })
+    } catch (notifyError) {
+      logger.error('Failed to send Discord notification', notifyError as Error)
+    }
     return
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
-import puppeteer, { LaunchOptions } from 'puppeteer-core'
+import { setTimeout as delay } from 'node:timers/promises'
+import puppeteer, { Browser, LaunchOptions } from 'puppeteer-core'
 import Amazon from './amazon'
 import Booklog, { BooklogBook } from './booklog'
 import { Logger, Discord, DiscordOptions } from '@book000/node-utils'
@@ -249,6 +250,98 @@ async function updateAllBooks(
 }
 
 /**
+ * Chromium のプロファイルロックファイル名一覧
+ */
+const CHROMIUM_SINGLETON_LOCK_FILES = [
+  'SingletonLock',
+  'SingletonCookie',
+  'SingletonSocket',
+]
+
+/**
+ * Chromium 起動失敗時の診断情報(DISPLAY/Xvfb ソケット・userDataDir のロックファイル状態)をログに出力する
+ *
+ * @param logger ロガー
+ * @param userDataDir Chromium の userDataDir パス
+ */
+function logChromiumLaunchDiagnostics(logger: Logger, userDataDir: string) {
+  const display = process.env.DISPLAY
+  logger.warn(`Chromium launch diagnostics: DISPLAY=${display ?? '(not set)'}`)
+
+  if (display) {
+    // entrypoint.sh と同じ規則で X11 ソケットパスを組み立てる(":99" -> "X99")
+    const displayNumber = display.replace(/^:/, '').split('.', 1)[0]
+    const socketPath = `/tmp/.X11-unix/X${displayNumber}`
+    logger.warn(
+      `Chromium launch diagnostics: X11 socket (${socketPath}) ${
+        fs.existsSync(socketPath) ? 'exists' : 'missing'
+      }`
+    )
+  }
+
+  for (const lockFile of CHROMIUM_SINGLETON_LOCK_FILES) {
+    const lockPath = `${userDataDir}/${lockFile}`
+    logger.warn(
+      `Chromium launch diagnostics: ${lockFile} ${
+        fs.existsSync(lockPath) ? 'exists' : 'missing'
+      }`
+    )
+  }
+}
+
+/**
+ * userDataDir 配下の Chromium のロックファイル(Singleton*)を削除する
+ *
+ * @param userDataDir Chromium の userDataDir パス
+ */
+function removeChromiumSingletonLocks(userDataDir: string) {
+  for (const lockFile of CHROMIUM_SINGLETON_LOCK_FILES) {
+    const lockPath = `${userDataDir}/${lockFile}`
+    if (fs.existsSync(lockPath)) {
+      fs.rmSync(lockPath, { force: true })
+    }
+  }
+}
+
+/**
+ * 診断ログを出力しつつ Chromium を起動する。起動に失敗した場合、ロックファイルを削除した上で 1 回だけリトライする
+ *
+ * @param options puppeteer の起動オプション
+ * @param logger ロガー
+ * @returns 起動した Browser インスタンス
+ */
+async function launchBrowserWithDiagnostics(
+  options: LaunchOptions,
+  logger: Logger
+): Promise<Browser> {
+  const userDataDir = options.userDataDir ?? ''
+
+  logger.info('Launching Chromium (attempt 1/2)')
+  logChromiumLaunchDiagnostics(logger, userDataDir)
+
+  try {
+    return await puppeteer.launch(options)
+  } catch (error) {
+    logger.error('Failed to launch Chromium (attempt 1/2)', error as Error)
+    // ロック削除前の状態を記録してから自衛的なクリーンアップを行う
+    logChromiumLaunchDiagnostics(logger, userDataDir)
+    removeChromiumSingletonLocks(userDataDir)
+    await delay(3000)
+  }
+
+  logger.info('Launching Chromium (attempt 2/2)')
+  logChromiumLaunchDiagnostics(logger, userDataDir)
+
+  try {
+    return await puppeteer.launch(options)
+  } catch (error) {
+    logger.error('Failed to launch Chromium (attempt 2/2)', error as Error)
+    logChromiumLaunchDiagnostics(logger, userDataDir)
+    throw error
+  }
+}
+
+/**
  * メイン処理
  */
 async function main() {
@@ -264,12 +357,16 @@ async function main() {
     ? Number.parseInt(process.env.WINDOW_HEIGHT)
     : 1000
 
+  const userDataDir = process.env.BROWSER_USER_DATA_DIR ?? 'data/userdata'
+
   // puppeteerの設定
   const puppeteerOptions: LaunchOptions = {
     // DISPLAYがないときはheadlessモードにする
     headless: !process.env.DISPLAY,
     executablePath: process.env.CHROMIUM_PATH ?? '/usr/bin/chromium-browser',
-    userDataDir: process.env.BROWSER_USER_DATA_DIR ?? 'data/userdata',
+    userDataDir,
+    // 起動失敗時の診断のため、Chromium自身のstdout/stderrをそのまま出力する
+    dumpio: true,
     defaultViewport: {
       width,
       height,
@@ -294,7 +391,28 @@ async function main() {
   // discordの設定
   const discord = new Discord(config.discord)
 
-  const browser = await puppeteer.launch(puppeteerOptions)
+  let browser: Awaited<ReturnType<typeof launchBrowserWithDiagnostics>>
+  try {
+    browser = await launchBrowserWithDiagnostics(puppeteerOptions, logger)
+  } catch (error) {
+    logger.error('Failed to launch Chromium', error as Error)
+    await discord.sendMessage({
+      embeds: [
+        {
+          title: 'Chromiumの起動に失敗しました',
+          description:
+            error instanceof Error
+              ? error.message + '\n\n' + (error.stack ?? '')
+              : String(error),
+          color: 0xff_00_00, // red
+          footer: {
+            text: 'Powered by kindle-booklog',
+          },
+        },
+      ],
+    })
+    return
+  }
 
   try {
     const amazon = new Amazon(


### PR DESCRIPTION
## 概要

Chromium 起動時の `Timed out after 30000 ms while waiting for the WS endpoint URL to appear in stdout!`(GlitchTip `KINDLE-BOOKLOG-4` / issue 115)への対応。

## 変更内容

- `dumpio: true` を追加し、Chromium 自身の stdout/stderr をログへ出力
- 起動前に DISPLAY/X11 ソケット状態、userDataDir のロックファイル(`Singleton*`)状態を診断ログとして出力
- `puppeteer.launch()` の起動失敗時、ロックファイルを削除した上で 1 回だけ安全にリトライ(合計 2 回試行)
- 起動が最終的に失敗した場合、Discord へ通知するよう修正(従来は launch 失敗時に通知されない構造上のギャップがあった)
- 診断ログには DISPLAY 値・ソケット/ロックファイルの存在有無(真偽値)のみを出力し、認証情報等の秘密情報は含めない
- deep-review の指摘(冗長 JSDoc、コメントの半角スペース不足、Discord 通知失敗時の未処理例外化、embed description の 4096 文字超過リスク、リトライ 1 回目のエラー情報欠落)を修正済み

## CI

`hadolint` が `Dockerfile:17` の DL3066(info)で失敗していますが、本 PR は `Dockerfile` を変更しておらず既存事象のため対応していません。他のチェックは全て pass しています。

Closes #2481

Spec: https://github.com/book000/kindle-booklog/issues/2481#issuecomment-5307180730
Plan: https://github.com/book000/kindle-booklog/issues/2481#issuecomment-5307215360
